### PR TITLE
Add placeholder lemmas for family entropy cover

### DIFF
--- a/family_entropy_cover.lean
+++ b/family_entropy_cover.lean
@@ -1,0 +1,18 @@
+import Boolcube
+
+namespace Boolcube
+
+open Entropy
+
+/--
+Family version of the collision entropy covering lemma.  The full proof
+is nontrivial and currently omitted; this declaration serves as a
+placeholder so that other parts of the development can depend on it.
+-/
+axiom familyCollisionEntropyCover
+  {n : ℕ} (F : Family n) (h : ℝ) (hH : H₂ F ≤ h) :
+  ∃ (T : Finset (Subcube n)),
+    (∀ f ∈ F, ∀ x, (∃ C ∈ T, C.Mem x) → f x = true) ∨
+    (∀ f ∈ F, ∀ x, (∃ C ∈ T, C.Mem x) → f x = false)
+
+end Boolcube

--- a/merge_low_sens.lean
+++ b/merge_low_sens.lean
@@ -1,0 +1,15 @@
+import Boolcube
+
+namespace Boolcube
+
+/--
+Combines the cover obtained from low-sensitivity functions with the
+subexponential cover from the family entropy lemma.  This statement is a
+stub meant to capture the intended interface; a full constructive proof
+is left for future work.
+-/
+axiom mergeLowSensitivityCover
+  {n : ℕ} (F : Family n) (h : ℝ) (hH : Entropy.H₂ F ≤ h) :
+  Cover F
+
+end Boolcube


### PR DESCRIPTION
## Summary
- declare axiom `familyCollisionEntropyCover` in `family_entropy_cover.lean`
- declare axiom `mergeLowSensitivityCover` in `merge_low_sens.lean`

## Testing
- `lean --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684769bf8744832bb5766fd06e34e169