### PR TITLE
Replace axioms with theorem placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,8 @@
+# N-np formalization repository
+
+This repo contains experimental Lean code attempting to formalize aspects of a hypothetical proof that `P ≠ NP`. The development is highly incomplete. Several files include placeholders (`sorry` or `admit`). In particular:
+
+- `Boolcube.lean` defines basic structures and begins a construction for rectangle covers. The major lemmas rely on unproven assumptions.
+- `family_entropy_cover.lean` and `merge_low_sens.lean` previously declared axioms. They now contain theorem statements with proof holes marked by `sorry`.
+
+The repository is mainly a research sketch rather than a working proof. See `experiments/` for a small Python script exploring combinatorial data.

--- a/family_entropy_cover.lean
+++ b/family_entropy_cover.lean
@@ -9,10 +9,15 @@ Family version of the collision entropy covering lemma.  The full proof
 is nontrivial and currently omitted; this declaration serves as a
 placeholder so that other parts of the development can depend on it.
 -/
-axiom familyCollisionEntropyCover
+/--
+`familyCollisionEntropyCover` is stated as a theorem rather than an axiom.
+The body is still unfinished and uses `sorry` as a placeholder.
+-/
+theorem familyCollisionEntropyCover
   {n : ℕ} (F : Family n) (h : ℝ) (hH : H₂ F ≤ h) :
   ∃ (T : Finset (Subcube n)),
     (∀ f ∈ F, ∀ x, (∃ C ∈ T, C.Mem x) → f x = true) ∨
-    (∀ f ∈ F, ∀ x, (∃ C ∈ T, C.Mem x) → f x = false)
+    (∀ f ∈ F, ∀ x, (∃ C ∈ T, C.Mem x) → f x = false) := by
+  sorry
 
 end Boolcube

--- a/merge_low_sens.lean
+++ b/merge_low_sens.lean
@@ -8,8 +8,14 @@ subexponential cover from the family entropy lemma.  This statement is a
 stub meant to capture the intended interface; a full constructive proof
 is left for future work.
 -/
-axiom mergeLowSensitivityCover
+/--
+Placeholder theorem combining low-sensitivity covers with the
+entropy-based family cover.  A full constructive proof remains
+to be written.  The statement is kept as a theorem so that other
+files may depend on it.-/
+theorem mergeLowSensitivityCover
   {n : ℕ} (F : Family n) (h : ℝ) (hH : Entropy.H₂ F ≤ h) :
-  Cover F
+  Cover F := by
+  sorry
 
 end Boolcube


### PR DESCRIPTION
## Summary
- note that this repo is an incomplete research sketch
- convert `family_entropy_cover` and `merge_low_sens` axioms into theorems using `sorry`
- add a small README describing the repository

## Testing
- `python3 experiments/lemma_b_search.py`


------
https://chatgpt.com/codex/tasks/task_e_68476c8bbbe8832b967e0521580e9e3b